### PR TITLE
Ensure cache directory exists for map tiles

### DIFF
--- a/global.php
+++ b/global.php
@@ -84,7 +84,11 @@ function latPerPixel($tileNo, $zoom) {
  */
 function fetchTile($url) {
 
-    $cacheTileName = "cache/tile_" . md5($url) . ".jpg";
+    $cacheDir = __DIR__ . "/cache";
+    if (!is_dir($cacheDir)) {
+        mkdir($cacheDir, 0775, true);
+    }
+    $cacheTileName = $cacheDir . "/tile_" . md5($url) . ".jpg";
     if (file_exists($cacheTileName) && filesize($cacheTileName) > 100) {
         return file_get_contents($cacheTileName);
     }


### PR DESCRIPTION
### Motivation
- The tile caching code assumed a `cache` directory existed which caused errors when missing, so the runtime should create the directory before storing downloaded map tiles.

### Description
- Added resolution of the cache path using `__DIR__ . "/cache"`, created it when missing with `mkdir($cacheDir, 0775, true)`, and updated the cached tile filename to use the resolved path in `global.php`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970ad250d3c83268897fb6ee9516589)