### PR TITLE
Use absolute font paths with __DIR__ to fix GD imagettf warnings

### DIFF
--- a/index.php
+++ b/index.php
@@ -152,8 +152,8 @@ class EvDashboardOverview {
      */
     private function prepareColors() {
 
-        $this->font = 'fonts/RobotoCondensed-Light.ttf';
-        $this->font2 = 'fonts/RobotoCondensed-Bold.ttf';
+        $this->font = __DIR__ . '/fonts/RobotoCondensed-Light.ttf';
+        $this->font2 = __DIR__ . '/fonts/RobotoCondensed-Bold.ttf';
         $this->white = imagecolorallocate($this->image, 255, 255, 255);
         $this->black = imagecolorallocate($this->image, 0, 0, 0);
         $this->red = imagecolorallocate($this->image, 255, 0, 0);


### PR DESCRIPTION
### Motivation
- The GD text functions were emitting `imagettftext()`/`imagettfbbox()` warnings because font files were referenced with relative paths and could not be found when the script ran from a different working directory.

### Description
- Update `index.php` to assign font paths using `__DIR__ . '/fonts/...'` so the TTF files are resolved from the script directory (avoids missing-font errors when calling `imagettftext()`/`imagettfbbox()`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970b07d013c8326bec7a291b815e219)